### PR TITLE
JdbcToBigQueryTruncateLoad.java

### DIFF
--- a/src/main/java/com/google/cloud/teleport/templates/JdbcToBigQueryTruncateLoad.java
+++ b/src/main/java/com/google/cloud/teleport/templates/JdbcToBigQueryTruncateLoad.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.teleport.templates;
+
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.cloud.teleport.io.DynamicJdbcIO;
+import com.google.cloud.teleport.templates.common.JdbcConverters;
+import com.google.cloud.teleport.util.KMSEncryptedNestedValueProvider;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.gcp.bigquery.TableRowJsonCoder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A template that copies data from a relational database using JDBC to an existing BigQuery table by using Truncate/Load method.
+ */
+public class JdbcToBigQueryTruncateLoad {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcToBigQueryTruncateLoad.class);
+
+  private static ValueProvider<String> maybeDecrypt(
+      ValueProvider<String> unencryptedValue, ValueProvider<String> kmsKey) {
+    return new KMSEncryptedNestedValueProvider(unencryptedValue, kmsKey);
+  }
+
+  /**
+   * Main entry point for executing the pipeline. This will run the pipeline asynchronously. If
+   * blocking execution is required, use the {@link
+   * JdbcToBigQuery#run(JdbcConverters.JdbcToBigQueryOptions)} method to start the pipeline and
+   * invoke {@code result.waitUntilFinish()} on the {@link PipelineResult}
+   *
+   * @param args The command-line arguments to the pipeline.
+   */
+  public static void main(String[] args) {
+
+    // Parse the user options passed from the command-line
+    JdbcConverters.JdbcToBigQueryOptions options =
+        PipelineOptionsFactory.fromArgs(args)
+            .withValidation()
+            .as(JdbcConverters.JdbcToBigQueryOptions.class);
+
+    run(options);
+  }
+
+  /**
+   * Runs the pipeline with the supplied options.
+   *
+   * @param options The execution parameters to the pipeline.
+   * @return The result of the pipeline execution.
+   */
+  private static PipelineResult run(JdbcConverters.JdbcToBigQueryOptions options) {
+    // Create the pipeline
+    Pipeline pipeline = Pipeline.create(options);
+
+    /*
+     * Steps: 1) Read records via JDBC and convert to TableRow via RowMapper
+     *        2) Truncate and Load all TableRows to BigQuery via BigQueryIO
+     */
+    pipeline
+        /*
+         * Step 1: Read records via JDBC and convert to TableRow
+         *         via {@link org.apache.beam.sdk.io.jdbc.JdbcIO.RowMapper}
+         */
+        .apply(
+            "Read from JdbcIO",
+            DynamicJdbcIO.<TableRow>read()
+                .withDataSourceConfiguration(
+                    DynamicJdbcIO.DynamicDataSourceConfiguration.create(
+                            options.getDriverClassName(),
+                            maybeDecrypt(options.getConnectionURL(), options.getKMSEncryptionKey()))
+                        .withUsername(
+                            maybeDecrypt(options.getUsername(), options.getKMSEncryptionKey()))
+                        .withPassword(
+                            maybeDecrypt(options.getPassword(), options.getKMSEncryptionKey()))
+                        .withDriverJars(options.getDriverJars())
+                        .withConnectionProperties(options.getConnectionProperties()))
+                .withQuery(options.getQuery())
+                .withCoder(TableRowJsonCoder.of())
+                .withRowMapper(JdbcConverters.getResultSetToTableRow(options.getUseColumnAlias())))
+        /*
+         * Step 2: Truncate And Load all TableRows to an existing BigQuery table
+         */
+        .apply(
+            "Write to BigQuery",
+            BigQueryIO.writeTableRows()
+                .withoutValidation()
+                .withCreateDisposition(BigQueryIO.Write.CreateDisposition.CREATE_NEVER)
+                .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE)
+                .withCustomGcsTempLocation(options.getBigQueryLoadingTemporaryDirectory())
+                .to(options.getOutputTable()));
+
+    // Execute the pipeline and return the result.
+    return pipeline.run();
+  }
+}


### PR DESCRIPTION
Created Truncate And Load capable JDBC to BigQuery template. Useful for cases where customers want to perform Full refresh every day of tables from Source databases to BigQuery.